### PR TITLE
settings fix

### DIFF
--- a/brownfield_django/settings_shared.py
+++ b/brownfield_django/settings_shared.py
@@ -1,6 +1,4 @@
 # flake8: noqa
-from settings_local import *
-
 # Django settings for brownfield_django project.
 import os.path
 import sys
@@ -63,6 +61,7 @@ USE_I18N = False
 MEDIA_ROOT = "/var/www/brownfield_django/uploads/"
 MEDIA_URL = '/uploads/'
 STATIC_URL = '/media/'
+SECRET_KEY = 'there-has-to-be-one-of-these-in-here'
 
 TEMPLATE_LOADERS = (
     'django.template.loaders.filesystem.Loader',


### PR DESCRIPTION
Django requires that something be set for the SECRET_KEY. Our convention across projects is that it gets overridden in production by the _real_ secret key in `local_settings.py` which Salt deploys to the correct location.
