### PR TITLE
check for anonymous user on team home view

### DIFF
--- a/brownfield_django/main/tests/test_views.py
+++ b/brownfield_django/main/tests/test_views.py
@@ -1,5 +1,6 @@
 from django.test import TestCase, RequestFactory
 from django.test.client import Client
+from .factories import TeamFactory
 
 
 class BasicTest(TestCase):
@@ -29,3 +30,13 @@ class TestAnnonymousUserLogin(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEquals(response.redirect_chain[0],
                           ('http://testserver/accounts/login/?next=/', 302))
+
+
+class TestAnonymousTeamHome(TestCase):
+    def setUp(self):
+        self.client = Client()
+
+    def test_denied(self):
+        t = TeamFactory()
+        r = self.client.get("/team/home/%d/" % t.pk)
+        self.assertEqual(r.status_code, 403)

--- a/brownfield_django/main/views.py
+++ b/brownfield_django/main/views.py
@@ -464,7 +464,8 @@ class TeamHomeView(DetailView):
     success_url = '/'
 
     def dispatch(self, *args, **kwargs):
-        if int(kwargs.get('pk')) != self.request.user.team.id:
+        if (self.request.user.is_anonymous()
+                or (int(kwargs.get('pk')) != self.request.user.team.id)):
             return HttpResponseForbidden("forbidden")
         return super(TeamHomeView, self).dispatch(*args, **kwargs)
 


### PR DESCRIPTION
Fixes this sentry error: https://sentry.ccnmtl.columbia.edu/brownfield_django/brownfield_django/group/492/