### PR TITLE
Fix bucket name

### DIFF
--- a/brownfield_django/settings_production.py
+++ b/brownfield_django/settings_production.py
@@ -8,9 +8,12 @@ locals().update(
         base=base,
         INSTALLED_APPS=INSTALLED_APPS,
         STATIC_ROOT=STATIC_ROOT,
+        AWS_STORAGE_BUCKET_NAME='ccnmtl-brownfield-static-prod'
     ))
 
 AWS_STORAGE_BUCKET_NAME = 'ccnmtl-brownfield-static-prod'
+S3_URL = 'https://%s.s3.amazonaws.com/' % AWS_STORAGE_BUCKET_NAME
+STATIC_URL = ('https://%s.s3.amazonaws.com/media/' % AWS_STORAGE_BUCKET_NAME)
 
 try:
     from local_settings import *

--- a/brownfield_django/settings_production.py
+++ b/brownfield_django/settings_production.py
@@ -8,7 +8,6 @@ locals().update(
         base=base,
         INSTALLED_APPS=INSTALLED_APPS,
         STATIC_ROOT=STATIC_ROOT,
-        AWS_STORAGE_BUCKET_NAME='ccnmtl-brownfield-static-prod'
     ))
 
 AWS_STORAGE_BUCKET_NAME = 'ccnmtl-brownfield-static-prod'

--- a/brownfield_django/settings_staging.py
+++ b/brownfield_django/settings_staging.py
@@ -8,7 +8,6 @@ locals().update(
         base=base,
         STATIC_ROOT=STATIC_ROOT,
         INSTALLED_APPS=INSTALLED_APPS,
-        AWS_STORAGE_BUCKET_NAME='ccnmtl-brownfield-static-stage'
     ))
 
 AWS_STORAGE_BUCKET_NAME = 'ccnmtl-brownfield-static-stage'

--- a/brownfield_django/settings_staging.py
+++ b/brownfield_django/settings_staging.py
@@ -8,9 +8,12 @@ locals().update(
         base=base,
         STATIC_ROOT=STATIC_ROOT,
         INSTALLED_APPS=INSTALLED_APPS,
+        AWS_STORAGE_BUCKET_NAME='ccnmtl-brownfield-static-stage'
     ))
 
 AWS_STORAGE_BUCKET_NAME = 'ccnmtl-brownfield-static-stage'
+S3_URL = 'https://%s.s3.amazonaws.com/' % AWS_STORAGE_BUCKET_NAME
+STATIC_URL = ('https://%s.s3.amazonaws.com/media/' % AWS_STORAGE_BUCKET_NAME)
 
 try:
     from local_settings import *


### PR DESCRIPTION
s3 buckets can't have underscores in the name, and there's a few more
things we need to do to override the default name.