### PR TITLE
Add django-crispy-forms

### DIFF
--- a/brownfield_django/settings_shared.py
+++ b/brownfield_django/settings_shared.py
@@ -30,6 +30,7 @@ INSTALLED_APPS += [  # noqa
     'typogrify',
     'bootstrapform',
     'django_extensions',
+    'crispy_forms',
     'registration',
     'pagetree',
     'pageblocks',

--- a/requirements.txt
+++ b/requirements.txt
@@ -73,6 +73,7 @@ django-pagetree==1.1.9
 django-pageblocks==1.0.3
 django-quizblock==1.1.4
 django-markwhat==1.4
+django-crispy-forms==1.6.0  # djangorestframework
 djangorestframework==3.3.2
 django-flashpolicies==1.6.1
 


### PR DESCRIPTION
Addressing compress error:
> Invalid template
> /var/www/brownfield_django/releases/green/brownfield_django/ve/local/lib/python2.7/site-packages/rest_framework/templates/rest_framework/filters/django_filter_crispyforms.html:
> 'crispy_forms_tags' is not a valid tag library: Template library
> crispy_forms_tags not found, tried
> django.templatetags.crispy_forms_tags,django.contrib.flatp ...

https://rolf.ccnmtl.columbia.edu/push/24073/