### PR TITLE
require post parameters for TeamPerformTestView

### DIFF
--- a/brownfield_django/main/tests/test_team_student_views.py
+++ b/brownfield_django/main/tests/test_team_student_views.py
@@ -80,6 +80,21 @@ class TestTeamViews(TestCase):
              'internalName': 'Document'})
         self.assertEqual(response.status_code, 200)
 
+    def test_teamperformtest_missing_params(self):
+        response = self.client.post(
+            "/team/" + str(self.team.user.pk) + "/test/",
+            {})
+        self.assertEqual(response.status_code, 400)
+
+    def test_teamperformtest_invalid_params(self):
+        response = self.client.post(
+            "/team/" + str(self.team.user.pk) + "/test/",
+            {'x': 'undefined', 'y': '450', 'testNumber': '2', 'z': '150',
+             'date': '2014/10/23 13:14', 'testDetails': 'some_details_here',
+             'paramString': 'some other values',
+             'description': 'description goes here', 'cost': '200'})
+        self.assertEqual(response.status_code, 400)
+
 
 class TestStudentViews(APITestCase):
 


### PR DESCRIPTION
This sentry error:
https://sentry.ccnmtl.columbia.edu/sentry-internal/brownfield_django/group/993/

It appears that the flash component is sometimes sending back invalid
requests, with 'undefined' instead of an integer value for some
parameters.

Ultimately, that's a bug in the flash part and ought to be fixed
there. But that's not going to happen any time soon. In the meantime,
the correct behavior for the backend is to respond with a 400 bad
request rather than throwing up a 500.

So I pulled out some basic validation. It's checking the parameters that
it's obviously expecting. I left a few off like 'description' and
'testDetails' because it's not clear to me whether those are actually
required or if it's OK for them to be None...