### PR TITLE
Resolve 500 error

### DIFF
--- a/brownfield_django/main/views.py
+++ b/brownfield_django/main/views.py
@@ -1,6 +1,15 @@
 import csv
 import json
 
+from brownfield_django.main.models import Course, UserProfile, Document, \
+    Team, History, Information, PerformedTest
+from brownfield_django.main.serializers import DocumentSerializer, \
+    UserSerializer, TeamUserSerializer, CourseSerializer, \
+    StudentUserSerializer, StudentMUserSerializer, InstructorSerializer
+from brownfield_django.main.xml_strings import INITIAL_XML
+from brownfield_django.mixins import LoggedInMixin, JSONResponseMixin, \
+    CSRFExemptMixin, PasswordMixin, UniqUsernameMixin, \
+    LoggedInMixinAdminInst, LoggedInMixinAdministrator, ProfileMixin
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
@@ -13,19 +22,8 @@ from django.template import loader
 from django.template.context import Context
 from django.views.generic import View
 from django.views.generic.detail import DetailView
-
 from rest_framework import status, viewsets
 from rest_framework.response import Response
-
-from brownfield_django.main.models import Course, UserProfile, Document, \
-    Team, History, Information, PerformedTest
-from brownfield_django.main.serializers import DocumentSerializer, \
-    UserSerializer, TeamUserSerializer, CourseSerializer, \
-    StudentUserSerializer, StudentMUserSerializer, InstructorSerializer
-from brownfield_django.main.xml_strings import INITIAL_XML
-from brownfield_django.mixins import LoggedInMixin, JSONResponseMixin, \
-    CSRFExemptMixin, PasswordMixin, UniqUsernameMixin, \
-    LoggedInMixinAdminInst, LoggedInMixinAdministrator
 
 
 class CourseViewSet(LoggedInMixin, viewsets.ModelViewSet):
@@ -398,16 +396,12 @@ class ShowProfessorsView(LoggedInMixin, LoggedInMixinAdministrator, View):
         return HttpResponse(edit_template)
 
 
-class CCNMTLHomeView(LoggedInMixin, LoggedInMixinAdminInst, DetailView):
+class CCNMTLHomeView(LoggedInMixin, LoggedInMixinAdminInst,
+                     ProfileMixin, DetailView):
 
     model = UserProfile
     template_name = 'main/ccnmtl/home_dash/ccnmtl_home.html'
     success_url = '/'
-
-    def dispatch(self, *args, **kwargs):
-        if int(kwargs.get('pk')) != self.request.user.profile.id:
-            return HttpResponseForbidden("forbidden")
-        return super(CCNMTLHomeView, self).dispatch(*args, **kwargs)
 
 
 class CCNMTLCourseDetail(LoggedInMixin, LoggedInMixinAdminInst, DetailView):

--- a/brownfield_django/mixins.py
+++ b/brownfield_django/mixins.py
@@ -1,11 +1,14 @@
 import json
 import random
 from string import letters, digits
+
 from django.contrib.auth.decorators import login_required, user_passes_test
-from django.http.response import HttpResponseNotAllowed, HttpResponse
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
+
 from django.contrib.auth.models import User
+from django.http.response import HttpResponseNotAllowed, HttpResponse, \
+    HttpResponseForbidden
 
 
 def ajax_required(func):
@@ -88,6 +91,14 @@ class LoggedInMixinAdministrator(object):
     def dispatch(self, *args, **kwargs):
         return super(
             LoggedInMixinAdministrator, self).dispatch(*args, **kwargs)
+
+
+class ProfileMixin(object):
+
+    def dispatch(self, *args, **kwargs):
+        if int(kwargs.get('pk')) != self.request.user.profile.id:
+            return HttpResponseForbidden("forbidden")
+        return super(ProfileMixin, self).dispatch(*args, **kwargs)
 
 
 class PasswordMixin(object):


### PR DESCRIPTION
AnonymousUser hitting the /ccnmtl/home/ url (CCNMTLHomeView) is resulting in a 500 error. The correct behavior should be a redirect to /login/.

At issue: The CCNMTLHomeView overrides dispatch, which bypasses the two LoggedInMixin guards. dispatch then attempts to access non-existent attributes on an AnonymousUser, causing the 500 error.

This PR creates a new mixin to verify a logged in user's profile id matches the passed parameter. The mixin is inserted into the constructor after the two LoggedInMixins, ensuring the user is not Anonymous.