### PR TITLE
Create Instructor: check for valid profile

### DIFF
--- a/media/js/ccnmtljs/bb_views.js
+++ b/media/js/ccnmtljs/bb_views.js
@@ -275,7 +275,7 @@ var InstructorView = BaseItemView.extend({
     render: function ()
     {
     	var prof = this.model.get('profile');
-        if (prof.archive === true) {
+        if (prof && prof.archive === true) {
             this.$el.remove();
         } else {
         	BaseItemView.prototype.render.apply(this, arguments);


### PR DESCRIPTION
When a new instructor is created, the user profile might not yet exist. Check for a valid profile before accessing properties on the model instance.