### PR TITLE
Use default server email

### DIFF
--- a/brownfield_django/settings_shared.py
+++ b/brownfield_django/settings_shared.py
@@ -48,8 +48,6 @@ PAGEBLOCKS = [
 ]
 
 EMAIL_SUBJECT_PREFIX = "[brownfield] "
-SERVER_EMAIL = 'ccnmtl-bfa@columbia.edu'
-DEFAULT_FROM_EMAIL = SERVER_EMAIL
 
 LOGIN_REDIRECT_URL = "/"
 


### PR DESCRIPTION
With Amazon SES, emails originating from our applications must come from an approved address. The application-specific mailing list address is available through the ui.