### PR TITLE
InstructorSerializer - profile serialization

### DIFF
--- a/brownfield_django/main/serializers.py
+++ b/brownfield_django/main/serializers.py
@@ -83,8 +83,7 @@ class InstructorSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = User
-        fields = ('id', 'first_name', 'last_name', 'email',
-                  'profile')
+        fields = ('id', 'first_name', 'last_name', 'email', 'profile')
 
     def create(self, validated_data):
         return User.objects.create(**validated_data)
@@ -96,4 +95,8 @@ class InstructorSerializer(serializers.ModelSerializer):
         instance.last_name = validated_data.get(
             'last_name', instance.last_name)
         instance.save()
+
+        self.fields['profile'].update(
+            instance.profile, validated_data.get('profile', {}))
+
         return instance

--- a/brownfield_django/main/views.py
+++ b/brownfield_django/main/views.py
@@ -205,7 +205,7 @@ class InstructorViewSet(LoggedInMixin, UniqUsernameMixin,
                 new_profile.tmp_passwd = tmpasswd
                 new_profile.save()
                 self.send_instructor_email(instructor, new_profile)
-                serializer = StudentMUserSerializer(instructor)
+                serializer = InstructorSerializer(instructor)
                 return Response(serializer.data, status.HTTP_201_CREATED)
             except:
                 return Response(status=status.HTTP_400_BAD_REQUEST)

--- a/media/js/ccnmtljs/bb_views.js
+++ b/media/js/ccnmtljs/bb_views.js
@@ -316,10 +316,10 @@ var InstructorView = BaseItemView.extend({
     },
 
     clear: function() {
-        var prof = _.clone(this.model.get('profile'));
-        prof.archive = true;
-        this.model.set('profile', prof);
-        this.model.save();
+        this.model.get('profile').archive = true;
+        this.model.save({
+            wait: true
+        });
     }
 
 });


### PR DESCRIPTION
The REST interaction here is unfortunately non-standard, and contributes to a bug around instructor removal (archive). This PR fixes an obvious serialization bug and puts a band-aid on the instructor removal until I can get back and do some more focused refactoring.

1. InstructorSerializer.update - make sure the nested profile is also serialized.
2. InstructorViewSet.update - serialize the InstructorProfile not the StudentProfile.
3. Cleanup the javascript