### PR TITLE
remove unnecessary test imports

### DIFF
--- a/brownfield_django/main/tests/__init__.py
+++ b/brownfield_django/main/tests/__init__.py
@@ -1,5 +1,0 @@
-# flake8: noqa
-from test_models import *
-from test_views import *
-from test_admin_views import *
-


### PR DESCRIPTION
no longer need to import those in __init__.py. All it does now is make
jenkins complain: https://jenkins.ccnmtl.columbia.edu/job/brownfield_django/violations/