### PR TITLE
add missing else

### DIFF
--- a/brownfield_django/main/models.py
+++ b/brownfield_django/main/models.py
@@ -141,12 +141,12 @@ class UserProfile(models.Model):
         return self.profile_type == 'AD'
 
     def role(self):
-        if self.is_student():
-            return "student"
+        if self.is_admin():
+            return "administrator"
         elif self.is_teacher():
             return "faculty"
-        elif self.is_admin():
-            return "administrator"
+        else:
+            return "student"
 
     def get_absolute_url(self):
         if self.is_teacher():


### PR DESCRIPTION
it was just bugging me to see an if/elif/elif with no else case in
there. it leaves this implicit case hanging there with no indication
whether that's a valid case or not (it's not).

I reversed the order so 'student' is the default fallback. If `role()`
is used for any sort of auth, that ensures that a bug in there would
most likely err on the side of the user getting a lower role than they
should rather than accidental privelege escalation.