### PR TITLE
Unaffix navbar

### DIFF
--- a/brownfield_django/templates/base.html
+++ b/brownfield_django/templates/base.html
@@ -41,7 +41,7 @@
     <a class="sr-only" href="#content">Skip navigation</a>
 
 {% block topnavbar %}
-<nav class="navbar navbar-default navbar-fixed-top" role="navigation">
+<nav class="navbar navbar-default" role="navigation">
   <!-- Brand and toggle get grouped for better mobile display -->
   <div class="container">
   <div class="navbar-header">

--- a/media/css/main.css
+++ b/media/css/main.css
@@ -16,11 +16,9 @@ body, html {
 	position: relative;
 	min-height: 100%;
 	margin-bottom: -100px;
-	margin-top: 100px;
 }
 
 #outer-container {
-    margin-top: 70px;
 	margin-bottom: 4em;
 }
 


### PR DESCRIPTION
The fixed style navbar overpainted the tabs for instructors & admins at minimum width. Opting to
simplify rather than add more esoteric .css rules.