### PR TITLE
Remove unused static flash path

### DIFF
--- a/brownfield_django/urls.py
+++ b/brownfield_django/urls.py
@@ -89,8 +89,6 @@ urlpatterns = [
     url(r'^crossdomain.xml$', flashpolicies.views.simple, {
         'domains': [static_flash_domain, '*.ccnmtl.columbia.edu']
     }),
-    url(r'^static/flash/documents/(?P<path>.*)$',
-        django.views.static.serve, {'document_root': settings.MEDIA_ROOT}),
     url(r'^admin/', include(admin.site.urls)),
     url(r'^_impersonate/', include('impersonate.urls')),
     url(r'^stats/$', TemplateView.as_view(template_name="stats.html")),


### PR DESCRIPTION
This route points `/static/flash/documents/` to `settings.MEDIA_ROOT`, which
is defined as `/var/www/brownfield_django/uploads/` in ccnmtlsettings.

First of all, `/var/www/brownfield_django/uploads/` is not a valid path
in our current deployment setup, so this variable should be updated in
ccnmtlsettings to reflect our S3 flow.

It's worth noting that updating MEDIA_ROOT to a valid local path, like
`/home/nnyby/src/d/brownfield_django/media/flash/documents/`, doesn't
solve PMT #109570.

All in all, this change should have no effect since accessing
`/static/flash/documents/slMap.pdf` returns a 404 before and after this
change.