### PR TITLE
Add document download links again - PMT #109570

### DIFF
--- a/brownfield_django/templates/main/ccnmtl/home_dash/demo_tab.html
+++ b/brownfield_django/templates/main/ccnmtl/home_dash/demo_tab.html
@@ -41,4 +41,13 @@
         </object>
 
     </div>
+    <div>
+        <h3>Document Downloads</h3>
+        <ul>
+            <li><a href="{% static 'flash/documents/slCatalog.pdf' %}">Self-Lume catalog</a></li>
+            <li><a href="{% static 'flash/documents/slBrochure.pdf' %}">Self-Lume brochure</a></li>
+            <li><a href="{% static 'flash/documents/slMap.pdf' %}">Self-Lume property map</a></li>
+            <li><a href="{% static 'flash/documents/contract.pdf' %}">Copy of contract text</a></li>
+        </ul>
+    </div>
 </div> <!-- tab-pane -->

--- a/brownfield_django/templates/main/team/team_home.html
+++ b/brownfield_django/templates/main/team/team_home.html
@@ -102,6 +102,15 @@
         </object>
     </div>
     </div>
+    <div>
+        <h3>Document Downloads</h3>
+        <ul>
+            <li><a href="{% static 'flash/documents/slCatalog.pdf' %}">Self-Lume catalog</a></li>
+            <li><a href="{% static 'flash/documents/slBrochure.pdf' %}">Self-Lume brochure</a></li>
+            <li><a href="{% static 'flash/documents/slMap.pdf' %}">Self-Lume property map</a></li>
+            <li><a href="{% static 'flash/documents/contract.pdf' %}">Copy of contract text</a></li>
+        </ul>
+    </div>
   </div><!-- End show game -->
     <br />
     {% endblock %}


### PR DESCRIPTION
I had previously added these links, and it caused the error noted at
PMT #109671. I've tested this new change on staging, but we will want to
test on production as well. We can do this by logging in as ccnmtl and
clicking the "Demo" tab, to make sure everything appears.

The static link needs to not include the initial slash, like:
`{% static 'flash/documents/slCatalog.pdf' %}`

And not:
`{% static '/flash/documents/slCatalog.pdf' %}`