### PR TITLE
Add missing ldap3 dependency: pyasn1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -47,6 +47,7 @@ six==1.10.0
 ipaddress==1.0.18
 Faker==0.7.7
 factory_boy==2.8.1
+pyasn1==0.1.9
 ldap3==2.2.0
 sqlparse==0.2.2
 contextlib2==0.5.4


### PR DESCRIPTION
fixes a djangowind warning:
  UserWarning: this requires a python ldap library.