### PR TITLE
Simplify the demo views

### DIFF
--- a/brownfield_django/main/tests/test_interactive.py
+++ b/brownfield_django/main/tests/test_interactive.py
@@ -1,109 +1,33 @@
 from django.test import TestCase
 from django.test.client import Client
-from factories import UserFactory, UserProfileFactory
 from brownfield_django.main.xml_strings import INITIAL_XML
 
 
-class TestAdminInfoInteractiveViews(TestCase):
+class TestDemoViews(TestCase):
 
     def setUp(self):
         self.client = Client()
-        self.admin = UserProfileFactory(user=UserFactory(username='admin'),
-                                        profile_type='AD')
-        self.client.login(username=self.admin.user.username, password="test")
 
-    def test_admin_info_get_interaction(self):
+    def test_info(self):
         response = self.client.get("/demo/info/")
-        self.assertEqual(response.content,
-                         "<data><response>OK</response></data>")
+        self.assertEqual(response.content, INITIAL_XML)
 
-    def test_admin_info_post_interaction(self):
         response = self.client.post("/demo/info/")
         self.assertEqual(response.content,
                          "<data><response>OK</response></data>")
 
-
-class TestInstructorInfoInteractiveViews(TestCase):
-
-    def setUp(self):
-        self.client = Client()
-        self.inst = UserProfileFactory(user=UserFactory(username='Teacher'),
-                                       profile_type='TE')
-        self.client.login(username=self.inst.user.username, password="test")
-
-    def test_instructor_info_get_interaction(self):
-        response = self.client.get("/demo/info/")
+    def test_history(self):
+        response = self.client.get("/demo/history/")
         self.assertEqual(response.content, INITIAL_XML)
 
-    def test_instructor_info_post_interaction(self):
-        response = self.client.post("/demo/info/")
+        response = self.client.post("/demo/history/")
         self.assertEqual(response.content,
                          "<data><response>OK</response></data>")
 
-
-class TestAdminHistoryInteractiveViews(TestCase):
-
-    def setUp(self):
-        self.client = Client()
-        self.admin = UserProfileFactory(user=UserFactory(username='admin'),
-                                        profile_type='AD')
-        self.client.login(username=self.admin.user.username, password="test")
-
-    def test_admin_history_get_interaction(self):
-        response = self.client.get("/demo/history/")
-        self.assertEqual(response.content, INITIAL_XML)
-
-    def test_admin_history_post_interaction(self):
-        response = self.client.post("/demo/history/")
-        self.assertEqual(response.content, INITIAL_XML)
-
-
-class TestInstructorHistoryInteractiveViews(TestCase):
-
-    def setUp(self):
-        self.client = Client()
-        self.inst = UserProfileFactory(user=UserFactory(username='Teacher'),
-                                       profile_type='TE')
-        self.client.login(username=self.inst.user.username, password="test")
-
-    def test_instructor_history_get_interaction(self):
-        response = self.client.get("/demo/history/")
-        self.assertEqual(response.content, INITIAL_XML)
-
-    def test_instructor_history_post_interaction(self):
-        response = self.client.post("/demo/history/")
-        self.assertEqual(response.content, INITIAL_XML)
-
-
-class TestAdminTestInteractiveViews(TestCase):
-
-    def setUp(self):
-        self.client = Client()
-        self.admin = UserProfileFactory(user=UserFactory(username='admin'),
-                                        profile_type='AD')
-        self.client.login(username=self.admin.user.username, password="test")
-
-    def test_admin_test_get_interaction(self):
+    def test_test(self):
         response = self.client.get("/demo/test/")
         self.assertEqual(response.content, INITIAL_XML)
 
-    def test_admin_test_post_interaction(self):
         response = self.client.post("/demo/test/")
-        self.assertEqual(response.content, INITIAL_XML)
-
-
-class TestInstructorTestInteractiveViews(TestCase):
-
-    def setUp(self):
-        self.client = Client()
-        self.inst = UserProfileFactory(user=UserFactory(username='Teacher'),
-                                       profile_type='TE')
-        self.client.login(username=self.inst.user.username, password="test")
-
-    def test_test_history_get_interaction(self):
-        response = self.client.get("/demo/test/")
-        self.assertEqual(response.content, INITIAL_XML)
-
-    def test_test_history_post_interaction(self):
-        response = self.client.post("/demo/test/")
-        self.assertEqual(response.content, INITIAL_XML)
+        self.assertEqual(response.content,
+                         "<data><response>OK</response></data>")

--- a/brownfield_django/main/views.py
+++ b/brownfield_django/main/views.py
@@ -437,47 +437,12 @@ class CCNMTLCourseDetail(LoggedInMixin, LoggedInMixinAdminInst, DetailView):
 '''CCNMTL/Admin Interactive Views'''
 
 
-class BrownfieldInfoView(CSRFExemptMixin, View):
-    '''Corresponds to "demo/info/"'''
-    def get(self, request):
-        if request.user.profile.is_admin():
-            return HttpResponse("<data><response>OK</response></data>")
-        elif request.user.profile.is_teacher():
-            '''This may need to be changed...'''
-            return HttpResponse(INITIAL_XML)
-
-    def post(self, request):
-        if request.user.profile.is_admin():
-            return HttpResponse("<data><response>OK</response></data>")
-        elif request.user.profile.is_teacher():
-            '''This may need to be changed...'''
-            return HttpResponse("<data><response>OK</response></data>")
-
-
-class BrownfieldHistoryView(CSRFExemptMixin, View):
-
+class BrownfieldDemoView(CSRFExemptMixin, View):
     def get(self, request):
         return HttpResponse(INITIAL_XML)
 
     def post(self, request):
-        return HttpResponse(INITIAL_XML)
-
-
-class BrownfieldTestView(CSRFExemptMixin, LoggedInMixin, View):
-
-    def get(self, request):
-        if request.user.profile.is_admin():
-            return HttpResponse(INITIAL_XML)
-        elif request.user.profile.is_teacher():
-            '''This may need to be changed...'''
-            return HttpResponse(INITIAL_XML)
-
-    def post(self, request):
-        if request.user.profile.is_admin():
-            return HttpResponse(INITIAL_XML)
-        elif request.user.profile.is_teacher():
-            '''This may need to be changed...'''
-            return HttpResponse(INITIAL_XML)
+        return HttpResponse("<data><response>OK</response></data>")
 
 
 '''Beginning of Team Views'''

--- a/brownfield_django/urls.py
+++ b/brownfield_django/urls.py
@@ -14,7 +14,7 @@ from brownfield_django.main.views import CourseViewSet, UserViewSet, \
 from brownfield_django.main.views import HomeView, \
     CCNMTLHomeView, CCNMTLCourseDetail, \
     TeamHomeView, EditTeamsView, ShowTeamsView, ActivateCourseView, \
-    BrownfieldInfoView, BrownfieldHistoryView, BrownfieldTestView, \
+    BrownfieldDemoView, \
     TeamHistoryView, TeamInfoView, TeamPerformTest, \
     TeamCSV, ShowProfessorsView, ArchiveCourseView, TeamSignContract
 
@@ -74,9 +74,9 @@ urlpatterns = [
     url(r'^show_instructors/$', ShowProfessorsView.as_view()),
     url(r'^demo/play$', TemplateView.as_view(
         template_name="main/flvplayer.html")),
-    url(r'^demo/info/', BrownfieldInfoView.as_view()),
-    url(r'^demo/history/', BrownfieldHistoryView.as_view()),
-    url(r'^demo/test/$', BrownfieldTestView.as_view()),
+    url(r'^demo/info/', BrownfieldDemoView.as_view()),
+    url(r'^demo/history/', BrownfieldDemoView.as_view()),
+    url(r'^demo/test/$', BrownfieldDemoView.as_view()),
     url(r'^team/home/(?P<pk>\d+)/$', TeamHomeView.as_view()),
     url(r'^team/(?P<pk>\d+)/play$', TeamHistoryView.as_view(),
         name='team-history'),


### PR DESCRIPTION
The demo experience can be supported with just one view that returns the same `get` and `post` responses for all queries from all users.