### PR TITLE
Update security settings

### DIFF
--- a/brownfield_django/main/tests/test_views.py
+++ b/brownfield_django/main/tests/test_views.py
@@ -105,9 +105,9 @@ class TestCSV(TestCase):
         self.assertEqual(a[0], b'Cost,Date,Description,X,Y,Z')
         self.assertEqual(a[1], b'100,2014/10/23 13:14,History Record')
         self.assertEqual(a[2], b'100,2014/10/23 13:14,History Record')
+        self.assertEqual(a[3], b'100,2014/10/23 13:14,History Record,10,30,60')
         self.assertEqual(
-            a[3], b'100,2014/10/23 13:14,History Record,10,30,None')
-        self.assertEqual(a[4], b'100,2014/10/23 13:14,History Record,10,30,60')
+            a[4], b'100,2014/10/23 13:14,History Record,10,30,None')
 
 
 class TestTeamHistoryView(TestCase):

--- a/brownfield_django/main/tests/test_views.py
+++ b/brownfield_django/main/tests/test_views.py
@@ -105,9 +105,9 @@ class TestCSV(TestCase):
         self.assertEqual(a[0], b'Cost,Date,Description,X,Y,Z')
         self.assertEqual(a[1], b'100,2014/10/23 13:14,History Record')
         self.assertEqual(a[2], b'100,2014/10/23 13:14,History Record')
-        self.assertEqual(a[3], b'100,2014/10/23 13:14,History Record,10,30,60')
         self.assertEqual(
-            a[4], b'100,2014/10/23 13:14,History Record,10,30,None')
+            a[3], b'100,2014/10/23 13:14,History Record,10,30,None')
+        self.assertEqual(a[4], b'100,2014/10/23 13:14,History Record,10,30,60')
 
 
 class TestTeamHistoryView(TestCase):

--- a/brownfield_django/settings_shared.py
+++ b/brownfield_django/settings_shared.py
@@ -19,6 +19,8 @@ TEMPLATES[0]['OPTIONS']['context_processors'].append(  # noqa
 
 MIDDLEWARE += [  # noqa
     'django.middleware.csrf.CsrfViewMiddleware',
+    'django.middleware.security.SecurityMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware'
 ]
 
 ROOT_URLCONF = 'brownfield_django.urls'
@@ -69,3 +71,9 @@ DEBUG_TOOLBAR_PATCH_SETTINGS = False
 
 SERVER_EMAIL = 'brownfield@ccnmtl.columbia.edu'
 CONTACT_US_EMAIL = 'ctl-bfa@columbia.edu'
+
+SESSION_COOKIE_SECURE = True
+CSRF_COOKIE_SECURE = True
+
+SESSION_COOKIE_HTTPONLY = True
+CSRF_COOKIE_HTTPONLY = True


### PR DESCRIPTION
* Add X-Frame-Option header to all responses
The header value is set to SAMEORIGIN by default. See more (https://docs.djangoproject.com/en/2.2/ref/clickjacking/)

* Set HttpOnly flag for Django cookies
https://docs.djangoproject.com/en/2.2/ref/settings/#csrf-cookie-httponly and https://docs.djangoproject.com/en/2.2/ref/settings/#session-cookie-httponly

* Flag Session & CSRF cooke as secure
https://docs.djangoproject.com/en/2.2/ref/settings/#csrf-cookie-secure

* Add SecurityMiddleware
https://docs.djangoproject.com/en/2.2/ref/middleware/#module-django.middleware.security
