### PR TITLE
Update csrf ajax approach

### DIFF
--- a/brownfield_django/templates/base.html
+++ b/brownfield_django/templates/base.html
@@ -6,9 +6,11 @@
 <head>
     <meta charset="utf-8" />
     <title>Brownfield Action {% block title %}{% endblock %}</title>
-      <meta name="viewport" content="width=device-width, initial-scale=1.0">
-      <meta name="description" content="djangoquizblock3">
-      <meta name="author" content="CCNMTL">
+
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="djangoquizblock3">
+    <meta name="author" content="CCNMTL">
+    <meta id="csrf-token" name="csrf-token" content="{{csrf_token}}">
 
 <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
 <!--[if lt IE 9]>

--- a/media/js/utility_scripts/backbone_sync.js
+++ b/media/js/utility_scripts/backbone_sync.js
@@ -22,10 +22,10 @@
 
       /* only need a token for non-get requests */
       if (method == 'create' || method == 'update' || method == 'delete') {
-          var csrfToken = getCookie('csrftoken');
+          const token = $('meta[name="csrf-token"]').attr('content');
 
           options.beforeSend = function(xhr){
-              xhr.setRequestHeader('X-CSRFToken', csrfToken);
+              xhr.setRequestHeader('X-CSRFToken', token);
           };
       }
 


### PR DESCRIPTION
Django cookies are now http only. Pull the csrf token from the page.