### PR TITLE
Fix redirect loop when logging in as new user

### DIFF
--- a/brownfield_django/main/models.py
+++ b/brownfield_django/main/models.py
@@ -146,16 +146,11 @@ class UserProfile(models.Model):
         # Note that a url of '/' can trigger a redirect loop in HomeView.
         url = '/'
 
-        if self.is_teacher():
-            url = '/ccnmtl/home/%s/' % (self.id)
-        elif self.is_admin():
+        if self.is_teacher() or self.is_admin():
             url = '/ccnmtl/home/%s/' % (self.id)
         else:
-            try:
-                team = Team.objects.get(user=self.user.pk)
-                url = '/team/home/%s/' % (team.pk)
-            except Team.DoesNotExist:
-                pass
+            team = Team.objects.get(user=self.user.pk)
+            url = '/team/home/%s/' % (team.pk)
 
         return url
 

--- a/brownfield_django/main/tests/test_models.py
+++ b/brownfield_django/main/tests/test_models.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 from django.test import TestCase
 from django.utils.encoding import smart_text
 
+from brownfield_django.main.models import Team
 from brownfield_django.main.tests.factories import (
     UserFactory, UserProfileFactory,
     CourseFactory, HistoryFactory, TeamFactory,
@@ -82,8 +83,16 @@ class UserProfileTest(TestCase):
         self.assertTrue(up.get_absolute_url().startswith('/ccnmtl/home/'))
         up = UserProfileFactory(profile_type='AD')
         self.assertTrue(up.get_absolute_url().startswith('/ccnmtl/home/'))
+
         up = UserProfileFactory(profile_type='ST')
-        self.assertEqual(up.get_absolute_url(), '/')
+        team = TeamFactory(user=up.user)
+        self.assertEqual(
+            up.get_absolute_url(), '/team/home/{}/'.format(team.pk))
+
+        # Student with no team
+        up = UserProfileFactory(profile_type='ST')
+        with self.assertRaises(Team.DoesNotExist):
+            up.get_absolute_url()
 
 
 class HistoryTest(TestCase):

--- a/brownfield_django/main/tests/test_views.py
+++ b/brownfield_django/main/tests/test_views.py
@@ -11,6 +11,7 @@ from brownfield_django.main.tests.factories import (
     UserFactory, UserProfileFactory, TeamFactory
 )
 from brownfield_django.main.views import TeamHistoryView
+from brownfield_django.main.models import Team
 
 
 class BasicTest(TestCase):
@@ -33,6 +34,13 @@ class HomeViewTest(TestCase):
     def test_get_as_anon_user(self):
         r = self.client.get('/', follow=True)
         self.assertEquals(r.status_code, 200)
+
+    def test_get_as_new_user(self):
+        user = UserFactory()
+        self.client.login(username=user.username, password='test')
+
+        with self.assertRaises(Team.DoesNotExist):
+            self.client.get('/', follow=True)
 
     def test_get_as_student(self):
         team = TeamFactory()

--- a/brownfield_django/main/views.py
+++ b/brownfield_django/main/views.py
@@ -328,6 +328,7 @@ class HomeView(LoggedInMixin, View):
         except UserProfile.DoesNotExist:
             '''First see if user is in admin group'''
             url = self.admin_or_team_url(request.user)
+
         return HttpResponseRedirect(url)
 
     def admin_or_team_url(self, user):
@@ -336,11 +337,8 @@ class HomeView(LoggedInMixin, View):
             up = UserProfile.objects.create(user=user, profile_type='AD')
             up.save()
         else:
-            try:
-                team = Team.objects.get(user=user.pk)
-                url = '/team/home/%s/' % (team.pk)
-            except Team.DoesNotExist:
-                pass
+            team = Team.objects.get(user=user.pk)
+            url = '/team/home/%s/' % (team.pk)
         return url
 
 


### PR DESCRIPTION
Throwing an error in this case is better than doing a redirect loop, as then at least we know what's wrong: The user needs either an Admin UserProfile assigned to it, or to be part of a Team.