### PR TITLE
update the Team budget if the course budget changes

### DIFF
--- a/brownfield_django/main/views.py
+++ b/brownfield_django/main/views.py
@@ -467,6 +467,10 @@ class TeamHomeView(LoggedInMixin, DetailView):
     def get_context_data(self, **kwargs):
         context = super(TeamHomeView, self).get_context_data(**kwargs)
         course = Course.objects.get(pk=self.object.course.pk)
+        if (self.object.budget != course.startingBudget):
+            Team.objects.filter(pk=self.object.pk).update(
+                budget=course.startingBudget)
+            self.object.refresh_from_db()
         context['document_list'] = course.document_set.filter(visible=True)
         return context
 


### PR DESCRIPTION
* The brownfield issue has to do with not triggering a change in the Team model field budget when the startingBudget field in the Course model is changed. This does the job but ideally I think we want to make the update to the Team model as soon as the Course model is changed. Trying to see how to get Backbone.js to do this